### PR TITLE
Add ttkbootstrap UI and analytics

### DIFF
--- a/storage.py
+++ b/storage.py
@@ -17,7 +17,7 @@ def load_sessions():
         with open(_data_file(), 'r') as f:
             return json.load(f)
     except Exception:
-        return {'sessions': {}, 'categories': {}}
+        return {'sessions_by_date': {}, 'categories': {}}
 
 
 def save_sessions(data):


### PR DESCRIPTION
## Summary
- migrate UI to ttkbootstrap window
- store sessions grouped by date in JSON
- add paned layout and bottom status bar
- replace buttons with icon images
- plot category and streak analytics

## Testing
- `python3 -m py_compile pomodoro.py storage.py`

------
https://chatgpt.com/codex/tasks/task_e_68569e4423488326947b2e5dd896b5a4