### PR TITLE
Add dark mode toggle and quick save field

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,5 @@ python3 pomodoro.py
 ```
 
 Press **Start** to begin the timer. A progress bar tracks each cycle and turns green during breaks. After four completed pomodoros a 15 minute long break is automatically scheduled. Use **Save** to record your progress. Sessions are written to `~/.pomopad/sessions_YYYY-MM.json` so they persist between runs. Saved sessions appear in a list on the right and can be filtered by category with the dropdown above the list. Double-click a session to view details or edit notes and category. Use the **🗂 Categories** button to create, rename or delete categories and pick a colour for each. The **Stats** button pops up a small bar chart of today's focused minutes per category. Use **Dock Bottom** or **Dock Right** to attach the window to the respective side of the screen on Windows.
+
+Below the timer is a single-line entry for a session name. Press **Enter** in this box to save the current session instantly without opening the dialog. A **Dark Mode** toggle lets you switch themes on the fly, and your choice is remembered next time you launch the app.

--- a/storage.py
+++ b/storage.py
@@ -15,9 +15,11 @@ def load_sessions():
     """Return saved sessions and categories from disk."""
     try:
         with open(_data_file(), 'r') as f:
-            return json.load(f)
+            data = json.load(f)
+            data.setdefault('theme', 'superhero')
+            return data
     except Exception:
-        return {'sessions_by_date': {}, 'categories': {}}
+        return {'sessions_by_date': {}, 'categories': {}, 'theme': 'superhero'}
 
 
 def save_sessions(data):


### PR DESCRIPTION
## Summary
- allow storing a preferred theme in JSON
- toggle between `superhero` and `darkly`
- add quick-save entry under the timer
- mention these features in docs

## Testing
- `python -m py_compile pomodoro.py storage.py`

------
https://chatgpt.com/codex/tasks/task_e_6856a482560c8326b07acfdcd150aa95