### PR TITLE
Add timer model and modern UI

### DIFF
--- a/tests/test_timer_model.py
+++ b/tests/test_timer_model.py
@@ -1,0 +1,34 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from timer_model import TimerModel
+
+
+def test_timer_transitions():
+    model = TimerModel(work=2, short_break=1, long_break=3)
+    model.start()
+    # finish work
+    model.tick()
+    model.tick()
+    assert model.state.mode == "break"
+    assert model.state.remaining == 1
+    # finish short break
+    model.tick()
+    assert model.state.mode == "work"
+    assert model.state.remaining == 2
+
+
+def test_long_break_cycle():
+    model = TimerModel(work=1, short_break=1, long_break=3)
+    model.start()
+    for i in range(4):
+        model.tick()
+        assert model.state.mode == "break"
+        expected = 3 if (i + 1) % 4 == 0 else 1
+        assert model.state.remaining == expected
+        # advance through the break
+        while model.state.mode == "break":
+            model.tick()
+        assert model.state.mode == "work"
+    assert model.pomo_count == 4

--- a/timer_model.py
+++ b/timer_model.py
@@ -1,0 +1,66 @@
+from dataclasses import dataclass
+import time
+
+WORK_DURATION = 25 * 60
+BREAK_DURATION = 5 * 60
+LONG_BREAK_DURATION = 15 * 60
+
+
+@dataclass
+class TimerState:
+    remaining: int
+    mode: str  # 'work' or 'break'
+    running: bool = False
+
+
+class TimerModel:
+    """Pure timer logic for the Pomodoro widget."""
+
+    def __init__(self, work: int = WORK_DURATION, short_break: int = BREAK_DURATION,
+                 long_break: int = LONG_BREAK_DURATION):
+        self.work = work
+        self.short_break = short_break
+        self.long_break = long_break
+        self.state = TimerState(work, "work", False)
+        self.pomo_count = 0
+        self.start_timestamp = None
+
+    def start(self):
+        if not self.state.running:
+            self.state.running = True
+            if self.state.mode == "work":
+                self.start_timestamp = time.time()
+
+    def stop(self):
+        self.state.running = False
+
+    def reset(self):
+        self.state.running = False
+        self.state.remaining = self.work
+        self.state.mode = "work"
+        self.pomo_count = 0
+
+    def tick(self):
+        """Advance the timer by one second and return an event string."""
+        if not self.state.running:
+            return None
+        if self.state.remaining > 0:
+            self.state.remaining -= 1
+        if self.state.remaining > 0:
+            return None
+
+        if self.state.mode == "work":
+            self.pomo_count += 1
+            self.state.mode = "break"
+            self.state.remaining = self.long_break if self.pomo_count % 4 == 0 else self.short_break
+            event = "work_complete"
+        else:
+            self.state.mode = "work"
+            self.state.remaining = self.work
+            event = "break_complete"
+        return event
+
+    def elapsed(self) -> int:
+        if self.state.mode == "work":
+            return self.work - self.state.remaining
+        return self.work

--- a/ui_analytics.py
+++ b/ui_analytics.py
@@ -1,0 +1,94 @@
+from datetime import datetime, timedelta
+import tkinter as tk
+from tkinter import ttk, messagebox
+from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg
+import matplotlib.pyplot as plt
+
+
+def aggregate(sessions_by_date, start_date, end_date):
+    total = {}
+    for date, sess in sessions_by_date.items():
+        if start_date <= date <= end_date:
+            for s in sess.values():
+                cat = s.get("category") or "Uncategorised"
+                total[cat] = total.get(cat, 0) + s.get("elapsed", 0)
+    return total
+
+
+def setup(frame):
+    period_var = tk.StringVar(value="Day")
+    toggle = ttk.Frame(frame)
+    toggle.pack(pady=2)
+    for val in ("Day", "Week", "Month"):
+        ttk.Radiobutton(toggle, text=val, variable=period_var, value=val).pack(side="left")
+
+    fig_cat, ax_cat = plt.subplots(figsize=(2.5, 2.5))
+    canvas_cat = FigureCanvasTkAgg(fig_cat, master=frame)
+    canvas_cat.get_tk_widget().pack()
+
+    fig_spark, ax_spark = plt.subplots(figsize=(2.5, 0.8))
+    canvas_spark = FigureCanvasTkAgg(fig_spark, master=frame)
+    canvas_spark.get_tk_widget().pack(fill="x")
+
+    return {
+        "period_var": period_var,
+        "ax_cat": ax_cat,
+        "ax_spark": ax_spark,
+        "canvas_cat": canvas_cat,
+        "canvas_spark": canvas_spark,
+    }
+
+
+def refresh(ctx, sessions_by_date):
+    end = datetime.now().date()
+    if ctx["period_var"].get() == "Day":
+        start = end
+    elif ctx["period_var"].get() == "Week":
+        start = end - timedelta(days=6)
+    else:
+        start = end - timedelta(days=29)
+
+    totals = aggregate(sessions_by_date, start.isoformat(), end.isoformat())
+    ctx["ax_cat"].clear()
+    if totals:
+        cats = list(totals.keys())
+        mins = [totals[c] / 60 for c in cats]
+        ctx["ax_cat"].pie(mins, labels=cats)
+    ctx["canvas_cat"].draw()
+
+    ctx["ax_spark"].clear()
+    vals = []
+    d = start
+    while d <= end:
+        key = d.isoformat()
+        total = sum(
+            s.get("elapsed", 0) / 60 for s in sessions_by_date.get(key, {}).values()
+        )
+        vals.append(total)
+        d += timedelta(days=1)
+    ctx["ax_spark"].plot(range(len(vals)), vals, color="blue")
+    ctx["ax_spark"].axis("off")
+    ctx["canvas_spark"].draw()
+
+
+def show_stats(master, sessions_by_date, categories):
+    today = datetime.now().date()
+    totals = {}
+    for sess in sessions_by_date.get(today.isoformat(), {}).values():
+        cat = sess.get("category", "")
+        totals[cat] = totals.get(cat, 0) + sess.get("elapsed", 0)
+    if not totals:
+        messagebox.showinfo("Stats", "No sessions recorded today")
+        return
+    fig, ax = plt.subplots(figsize=(4, 3))
+    cats = list(totals.keys())
+    mins = [totals[c] / 60 for c in cats]
+    ax.bar(cats, mins, color=[categories.get(c, "#888888") for c in cats])
+    ax.set_ylabel("Minutes")
+    ax.set_title("Today")
+    dialog = tk.Toplevel(master)
+    dialog.title("Daily Stats")
+    canvas = FigureCanvasTkAgg(fig, master=dialog)
+    canvas.draw()
+    canvas.get_tk_widget().pack()
+    ttk.Button(dialog, text="Close", command=dialog.destroy).pack(pady=5)


### PR DESCRIPTION
## Summary
- refactor timer logic into new `timer_model` module with unit tests
- switch main window theme to `ttk.Vista` and create notebook tabs
- move analytics plotting code to `ui_analytics`
- update application to use new modules and model

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856aecbcb3483268c7217e8d401be27