### PR TITLE
Improve theme toggle and icon loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,10 @@ This repository contains a simple Pomodoro timer written in Python. It provides 
 
 ## Usage
 
-Run the application with Python 3:
+Install dependencies with pip and run the application with Python 3:
 
 ```bash
+pip install pillow darkdetect
 python3 pomodoro.py
 ```
 


### PR DESCRIPTION
## Summary
- load icon `.ico` files with Pillow
- detect dark mode with `darkdetect` only if installed
- store theme preference as a boolean
- mention Pillow and darkdetect in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856c832a18c832681d0c83a6b27912c